### PR TITLE
always insert xtrace header arrays

### DIFF
--- a/httperfpy/__init__.py
+++ b/httperfpy/__init__.py
@@ -1,2 +1,4 @@
 from .httperfpy import Httperf, HttperfParser
 
+__version__ = '0.1.1'
+

--- a/httperfpy/httperfpy.py
+++ b/httperfpy/httperfpy.py
@@ -214,6 +214,9 @@ class HttperfParser(object):
                 unknown_lines.append(line)
                 continue
 
+        # add xtrace headers even if the array is empty.
+        self.matches['header_xtrace'] = xtrace_headers
+
         # the following ifs add the keys only if they are not empty.
         if len(verbose_connection_times):
             self.matches['connection_times'] = verbose_connection_times
@@ -221,8 +224,6 @@ class HttperfParser(object):
                 self.matches["connection_time_" + str(pct) + "_pct"] = \
                     self.__calculate_percentiles(pct, verbose_connection_times)
 
-        if len(xtrace_headers):
-            self.matches['header_xtrace'] = xtrace_headers
 
         if len(unknown_lines):
             self.matches['unknown_lines'] = unknown_lines

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 from distutils.core import setup
+from httperfpy import __version__
 
 setup(
     name='httperfpy',
-    version='0.0.5',
+    version=__version__,
     author='Joshua P. Mervine',
     author_email='joshua@mervine.net',
     packages=['httperfpy'],

--- a/unit/httperf_unit.py
+++ b/unit/httperf_unit.py
@@ -87,7 +87,7 @@ class HttperfTestCase(unittest.TestCase):
         httperf = Httperf()
         httperf.parser = True
         results = httperf.run()
-        self.assertEqual(len(results), 50)
+        self.assertEqual(len(results), 51)
 
     def testSluggedCmdArgs(self):
         httperf = Httperf(server="localhost", num_conns="5")

--- a/unit/parser_unit.py
+++ b/unit/parser_unit.py
@@ -21,7 +21,7 @@ class HttperfTestCase(unittest.TestCase):
 
     def testParseVerboseResultCount(self):
         vpresults = HttperfParser().parse(httperf_verbose_results)
-        self.assertEqual(len(vpresults.keys()), 58)
+        self.assertEqual(len(vpresults.keys()), 59)
         self.assertEqual(len(vpresults["connection_times"]), 10)
 
 if __name__ == "__main__":

--- a/unit/unit_helper.py
+++ b/unit/unit_helper.py
@@ -57,6 +57,7 @@ httperf_results_parsed = {
     'net_io_bps': '7.3*10^6', 'errors_total': '0', 'errors_client_timeout': '0', 'errors_socket_timeout': '0',
     'errors_conn_refused': '0', 'errors_conn_reset': '0', 'errors_fd_unavail': '0', 'errors_addr_unavail': '0',
     'errors_ftab_full': '0', 'errors_other': '0',
+    'header_xtrace': [],
     'httperf_colon_lines':
         ['httperf: warning: open file limit > FD_SETSIZE; limiting max. # of open files to FD_SETSIZE']
 }


### PR DESCRIPTION
- matches previous function
- update tests
- move version  to __init__.py and bump it to 0.1.1